### PR TITLE
Support for local SMS server for lab testing

### DIFF
--- a/appwrite_lab/templates/extras/twilio-shim/docker_compose.yml
+++ b/appwrite_lab/templates/extras/twilio-shim/docker_compose.yml
@@ -1,0 +1,62 @@
+x-sms-env: &sms_env
+  _APP_SMS_PROVIDER: ${_APP_SMS_PROVIDER:-sms://twilio:shim@twilio}
+  _APP_SMS_FROM:     ${_APP_SMS_FROM:-+15555555555}
+
+networks:
+  appwrite_net:
+    external: true
+    name: appwrite
+
+volumes:
+  fake_twilio_certs: {}
+  php_extra_conf: {}
+
+services:
+  # one-shot: write php ini into the named volume
+  php-ini-init:
+    image: busybox:1.36
+    volumes:
+      - php_extra_conf:/out
+    command: >
+      sh -lc 'printf "%s\n%s\n"
+      "curl.cainfo=/usr/local/share/ca-certificates/dev-rootCA.pem"
+      "openssl.cafile=/usr/local/share/ca-certificates/dev-rootCA.pem"
+      > /out/zz-dev-ca.ini'
+
+  twilio-shim:
+    image: syntaxsdev/twilio-shim:latest
+    volumes:
+      - fake_twilio_certs:/certs
+    ports: ["4443:443"]  # dev-only host access
+    networks:
+      appwrite_net:
+        aliases: [api.twilio.com]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD","curl","-k","https://localhost:443/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  appwrite:
+    depends_on:
+      php-ini-init: { condition: service_completed_successfully }
+    environment:
+      <<: *sms_env
+      PHP_INI_SCAN_DIR: /usr/local/etc/php/conf.d:/opt/php-extra-conf.d
+    volumes:
+      - fake_twilio_certs:/usr/local/share/ca-certificates:ro
+      - php_extra_conf:/opt/php-extra-conf.d:ro
+    networks: [appwrite_net]
+
+  appwrite-worker-messaging:
+    depends_on:
+      php-ini-init: { condition: service_completed_successfully }
+      twilio-shim:  { condition: service_healthy }
+    environment:
+      <<: *sms_env
+      PHP_INI_SCAN_DIR: /usr/local/etc/php/conf.d:/opt/php-extra-conf.d
+    volumes:
+      - fake_twilio_certs:/usr/local/share/ca-certificates:ro
+      - php_extra_conf:/opt/php-extra-conf.d:ro
+    networks: [appwrite_net]

--- a/twilio-shim/Dockerfile
+++ b/twilio-shim/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# deps
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# mkcert (static binary)
+RUN curl -L -o /usr/local/bin/mkcert \
+  https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 \
+ && chmod +x /usr/local/bin/mkcert
+
+# app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py ./main.py
+
+# entrypoint that generates certs then runs HTTPS
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 443
+ENTRYPOINT ["/entrypoint.sh"]

--- a/twilio-shim/entrypoint.sh
+++ b/twilio-shim/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CERT_DIR=${CERT_DIR:-/certs}
+CAROOT="${CERT_DIR}/ca"
+mkdir -p "${CAROOT}"
+
+# Generate CA + leaf if missing
+if [ ! -f "${CERT_DIR}/api.twilio.com.crt" ] || [ ! -f "${CERT_DIR}/api.twilio.com.key" ]; then
+  echo ">> Generating dev CA and leaf cert..."
+  export CAROOT
+  mkcert -install >/dev/null 2>&1 || true
+  mkcert -key-file "${CERT_DIR}/api.twilio.com.key" \
+         -cert-file "${CERT_DIR}/api.twilio.com.crt" \
+         "api.twilio.com"
+  cp "${CAROOT}/rootCA.pem" "${CERT_DIR}/dev-rootCA.pem"
+fi
+
+echo ">> Starting Twilio shim (HTTPS)…"
+exec uvicorn main:app \
+  --host 0.0.0.0 --port 443 \
+  --ssl-keyfile "${CERT_DIR}/api.twilio.com.key" \
+  --ssl-certfile "${CERT_DIR}/api.twilio.com.crt"

--- a/twilio-shim/main.py
+++ b/twilio-shim/main.py
@@ -1,0 +1,51 @@
+from fastapi import FastAPI, Body, Form
+from fastapi.responses import HTMLResponse, JSONResponse
+from typing import List, Dict
+from datetime import datetime
+
+app = FastAPI()
+MESSAGES: List[Dict] = []
+
+@app.post("/inbox")
+async def inbox(payload: Dict = Body(...)):
+    payload["ts"] = datetime.utcnow().isoformat() + "Z"
+    MESSAGES.append(payload)
+    if len(MESSAGES) > 100:
+        del MESSAGES[:-100]
+    return {"ok": True}
+
+@app.get("/inbox")
+def list_inbox():
+    return {"messages": MESSAGES}
+
+# Twilio-compatible endpoint
+@app.post("/2010-04-01/Accounts/{sid}/Messages.json")
+async def send_sms(sid: str, To: str = Form(...), From: str = Form(...), Body: str = Form(...)):
+    print(f"[FAKE-TWILIO] SID={sid} To={To} From={From} Body={Body}")
+    MESSAGES.append({
+        "to": To,
+        "frm": From,
+        "body": Body,
+        "ts": datetime.utcnow().isoformat() + "Z"
+    })
+    return JSONResponse(status_code=201, content={
+        "sid": "SM_fake123",
+        "status": "queued",
+        "to": To,
+        "from": From,
+        "body": Body,
+    })
+
+@app.get("/", response_class=HTMLResponse)
+def home():
+    rows = "".join(
+        f"<tr><td>{m.get('to','')}</td><td>{m.get('frm','')}</td><td>{m.get('body','')}</td><td>{m.get('ts','')}</td></tr>"
+        for m in reversed(MESSAGES)
+    )
+    return f"""
+    <html><head><meta charset="utf-8"><title>SMS Capture</title>
+    <style>table{{width:100%;border-collapse:collapse}}td,th{{border:1px solid #333;padding:6px}}</style>
+    </head><body>
+    <h3>Captured SMS (dev)</h3>
+    <table><thead><tr><th>To</th><th>From</th><th>Body</th><th>Time (UTC)</th></tr></thead><tbody>{rows}</tbody></table>
+    </body></html>"""

--- a/twilio-shim/main.py
+++ b/twilio-shim/main.py
@@ -1,10 +1,11 @@
-from fastapi import FastAPI, Body, Form
+from fastapi import FastAPI, Body, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from typing import List, Dict
 from datetime import datetime
 
 app = FastAPI()
 MESSAGES: List[Dict] = []
+
 
 @app.post("/inbox")
 async def inbox(payload: Dict = Body(...)):
@@ -14,32 +15,61 @@ async def inbox(payload: Dict = Body(...)):
         del MESSAGES[:-100]
     return {"ok": True}
 
+
 @app.get("/inbox")
 def list_inbox():
     return {"messages": MESSAGES}
 
+
 # Twilio-compatible endpoint
 @app.post("/2010-04-01/Accounts/{sid}/Messages.json")
-async def send_sms(sid: str, To: str = Form(...), From: str = Form(...), Body: str = Form(...)):
-    print(f"[FAKE-TWILIO] SID={sid} To={To} From={From} Body={Body}")
-    MESSAGES.append({
-        "to": To,
-        "frm": From,
-        "body": Body,
-        "ts": datetime.utcnow().isoformat() + "Z"
-    })
-    return JSONResponse(status_code=201, content={
-        "sid": "SM_fake123",
-        "status": "queued",
-        "to": To,
-        "from": From,
-        "body": Body,
-    })
+async def send_sms(sid: str, request: Request):
+    form = await request.form()
+    data = dict(form)  # includes any extra fields
+    to = data.get("To")
+    body = data.get("Body")
+    from_ = data.get("From")  # optional
+    mssid = data.get("MessagingServiceSid")  # optional
+
+    # Log everything we got to see what Appwrite is actually posting
+    print(f"[FAKE-TWILIO] sid={sid} payload={data}")
+    MESSAGES.append(
+        {
+            "to": to,
+            "frm": from_,
+            "body": body,
+            "ts": datetime.utcnow().isoformat() + "Z",
+        }
+    )
+
+    # Minimal Twilio-style validation: need To + Body + (From or MessagingServiceSid)
+    if not to or not body or not (from_ or mssid):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": 21601,
+                "message": "Missing required parameter: 'To'/'Body' or sender",
+            },
+        )
+
+    # Return Twilio-like success
+    return JSONResponse(
+        status_code=201,
+        content={
+            "sid": "SM_fake123",
+            "status": "queued",
+            "to": to,
+            "from": from_,
+            "messaging_service_sid": mssid,
+            "body": body,
+        },
+    )
+
 
 @app.get("/", response_class=HTMLResponse)
 def home():
     rows = "".join(
-        f"<tr><td>{m.get('to','')}</td><td>{m.get('frm','')}</td><td>{m.get('body','')}</td><td>{m.get('ts','')}</td></tr>"
+        f"<tr><td>{m.get('to', '')}</td><td>{m.get('frm', '')}</td><td>{m.get('body', '')}</td><td>{m.get('ts', '')}</td></tr>"
         for m in reversed(MESSAGES)
     )
     return f"""

--- a/twilio-shim/requirements.txt
+++ b/twilio-shim/requirements.txt
@@ -1,0 +1,14 @@
+annotated-types==0.7.0
+anyio==4.10.0
+click==8.2.1
+fastapi==0.116.1
+h11==0.16.0
+idna==3.10
+pydantic==2.11.7
+pydantic-core==2.33.2
+python-multipart==0.0.20
+sniffio==1.3.1
+starlette==0.47.2
+typing-extensions==4.14.1
+typing-inspection==0.4.1
+uvicorn==0.35.0


### PR DESCRIPTION
closes: https://github.com/syntaxsdev/appwrite-lab/issues/9

Twilio Shim drop-in masquerades as "api.twilio.com" and intercepts the calls.
PHP ini file is needed for PHP curl in utopia appwrite server correctly respects the self-signed cert.